### PR TITLE
fix: stabilize core combat and floor progression

### DIFF
--- a/CORE_RUN_STABILITY_NOTES.md
+++ b/CORE_RUN_STABILITY_NOTES.md
@@ -1,3 +1,0 @@
-# Core Run Stability Notes
-
-This temporary file should not exist.

--- a/CORE_RUN_STABILITY_NOTES.md
+++ b/CORE_RUN_STABILITY_NOTES.md
@@ -1,0 +1,3 @@
+# Core Run Stability Notes
+
+This temporary file should not exist.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,95 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Crypt of Greed
 
-## Getting Started
+Crypt of Greed is an early browser-based prototype for a turn-based deckbuilding roguelite. The current development goal is to validate a premium, offline-first game centered on a clear **bank-or-risk Greed mechanic** before expanding content or committing to a production engine.
 
-First, run the development server:
+The repository is not a release-ready Steam or console build. The product audit and source-of-truth plans are available in:
+
+- `PROJECT_REVIEW.md`
+- `GAME_DESIGN_DOCUMENT.md`
+- `GAMEPLAY_ANALYSIS.md`
+- `UI_UX_AUDIT.md`
+- `TECHNICAL_REVIEW.md`
+- `IMPLEMENTATION_ROADMAP.md`
+- `STEAM_READINESS.md`
+- `CONSOLE_READINESS.md`
+- `MONETIZATION_STRATEGY.md`
+
+## Current Technology
+
+- Next.js 15
+- React 19
+- TypeScript
+- Tailwind CSS
+- NextAuth
+- Prisma with MongoDB
+- Prototype wallet and NFT code that is under review and is not part of the recommended Steam or console product path
+
+## Requirements
+
+- Node.js 22 for the built-in TypeScript test runner used by this repository
+- npm
+- MongoDB connection string
+
+## Local Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Create `.env.local` with the values required by the current prototype:
+
+```bash
+DATABASE_URL=
+NEXTAUTH_SECRET=
+NEXTAUTH_URL=http://localhost:3000
+ENCRYPTION_KEY=
+NEXT_PUBLIC_RPC_URL=
+NEXT_PUBLIC_CONTRACT_ADDRESS=
+```
+
+The wallet-related values are still required by existing prototype modules. Do not use real funds or production private keys with the current implementation.
+
+3. Start development:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open `http://localhost:3000`.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Validation Commands
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+npm test
+npm run typecheck
+npm run build
+```
 
-## Learn More
+`npm test` currently covers the isolated combat and run-stability rules that do not require a database or browser.
 
-To learn more about Next.js, take a look at the following resources:
+## Verified Core Rules
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+- persisted character floors initialize the battle floor
+- opening combat does not draw two hands
+- ending a turn resolves one enemy turn
+- player block absorbs the enemy attack before resetting
+- defeated enemies remain available for reward calculation
+- seeded shuffling is repeatable
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Known Limitations
 
-## Deploy on Vercel
+- the full run/deck does not yet persist across every room
+- content is limited to a small starter card and enemy set
+- rest, shop, and event rooms remain prototype-level
+- no controller, keyboard-first input layer, audio system, accessibility suite, or native desktop build exists
+- save recovery, cloud saves, achievements, localization, and Steam integration are not implemented
+- wallet custody and NFT flows are not production-safe and are planned for removal from the commercial Steam/console path
+- a clean production build still requires configured services and dependencies
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Branch and Commit Rules
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- feature branches use `feat/<feature-name>`
+- commits follow Conventional Commits
+- do not add or modify GitHub Actions during the current stabilization phase

--- a/components/game/game-screen.tsx
+++ b/components/game/game-screen.tsx
@@ -21,28 +21,23 @@ export default function GameScreen({ onExit }: GameScreenProps) {
     if (!character) return;
 
     try {
-      // Update the floor first
       const nextFloor = (character.floor || 1) + 1;
-      await updateCharacter(character.id, {
-        floor: nextFloor,
-      });
+      await updateCharacter(character.id, { floor: nextFloor });
 
-      // Special case: force rest site every 5 floors
       if (nextFloor % 5 === 0) {
         setCurrentRoom(RoomType.REST);
         return;
       }
 
-      // Generate 2 random unique room options
       const possibleRooms = [
         RoomType.BATTLE,
         RoomType.REST,
         RoomType.SHOP,
         RoomType.EVENT,
       ];
-      const numberOfChoices = 2;
-      const shuffledRooms = [...possibleRooms].sort(() => Math.random() - 0.5);
-      const selectedRooms = shuffledRooms.slice(0, numberOfChoices);
+      const selectedRooms = [...possibleRooms]
+        .sort(() => Math.random() - 0.5)
+        .slice(0, 2);
 
       setAvailableRooms(selectedRooms);
       setShowRoomSelection(true);
@@ -61,7 +56,7 @@ export default function GameScreen({ onExit }: GameScreenProps) {
   const renderRoom = () => {
     switch (currentRoom) {
       case RoomType.BATTLE:
-        return <Combat onExit={onExit} onCombatEnd={handleContinue} />;
+        return <Combat onExit={onExit} />;
       case RoomType.REST:
         return <RestSite onContinue={handleContinue} />;
       case RoomType.SHOP:

--- a/components/game/rooms/combat.tsx
+++ b/components/game/rooms/combat.tsx
@@ -1,9 +1,12 @@
-import { Character } from "@/types/character";
-import { GameState, GameManager } from "@/lib/game/game-state";
-import { Enemy, EnemyManager } from "@/lib/game/enemy";
-import { useState, useEffect } from "react";
+import type { Character } from "@/types/character";
+import { GameManager, type GameState } from "@/lib/game/game-state";
+import { EnemyManager, type Enemy } from "@/lib/game/enemy";
+import { useEffect, useState } from "react";
 import { CombatManager } from "@/lib/game/combat-manager";
+import { calculateCombatRewards } from "@/lib/game/rewards";
+import { RoomType } from "@/lib/game/room-manager";
 import GameModal from "../end-battle-modal";
+import RoomSelectionModal from "../room-selection-modal";
 import CharacterStats from "../character-stats";
 import { useCharacter } from "@/context/character-context";
 import { toast } from "sonner";
@@ -12,34 +15,39 @@ import Card from "../card";
 import { Skull } from "lucide-react";
 
 interface CombatProps {
-  onCombatEnd: () => void;
   onExit: () => void;
 }
 
-enum RoomType {
-  BATTLE = "BATTLE",
-  REST = "REST",
-  SHOP = "SHOP",
-  EVENT = "EVENT",
+function createGameState(character: Character, floor = character.floor) {
+  return new GameManager({
+    ...character,
+    floor,
+    equipment: character.equipment || [],
+    powers: character.powers || [],
+    block: 0,
+    deck: [],
+    hand: [],
+    discardPile: [],
+  }).getState();
 }
 
-export default function Combat({ onCombatEnd, onExit }: CombatProps) {
-  const { character, updateCharacter, markCharacterAsDead, reviveCharacter } = useCharacter();
+export default function Combat({ onExit }: CombatProps) {
+  const { character, updateCharacter, markCharacterAsDead, reviveCharacter } =
+    useCharacter();
   const [gameState, setGameState] = useState<GameState | null>(null);
   const [enemies, setEnemies] = useState<Enemy[]>([]);
   const [combatManager, setCombatManager] = useState<CombatManager | null>(null);
   const [showVictory, setShowVictory] = useState(false);
   const [showDefeat, setShowDefeat] = useState(false);
-  const [rewards, setRewards] = useState<{
-    gold: number;
-    experience: number;
-    floor: number;
-  }>({ gold: 0, experience: 0, floor: 1 });
+  const [rewards, setRewards] = useState({
+    gold: 0,
+    experience: 0,
+    floor: 1,
+  });
   const [userCrystals, setUserCrystals] = useState(0);
-  const [defeatedEnemies, setDefeatedEnemies] = useState<Enemy[]>([]);
-  const router = useRouter();
   const [showRoomSelection, setShowRoomSelection] = useState(false);
   const [availableRooms, setAvailableRooms] = useState<RoomType[]>([]);
+  const router = useRouter();
 
   useEffect(() => {
     const fetchUserCrystals = async () => {
@@ -51,104 +59,52 @@ export default function Combat({ onCombatEnd, onExit }: CombatProps) {
         console.error("Failed to fetch user crystals:", error);
       }
     };
+
     fetchUserCrystals();
   }, []);
 
   useEffect(() => {
     if (!character) return;
 
-    // Initialize game state with enhanced character
-    const enhancedCharacter: Character = {
-      ...character,
-      equipment: character.equipment || [],
-      powers: character.powers || [],
-      block: 0,
-      deck: [],
-      hand: [],
-      discardPile: [],
-    };
-
-    const gameManager = new GameManager(enhancedCharacter);
-    const initialGameState = gameManager.getState();
-
-    // Create an enemy for the current floor
+    const initialGameState = createGameState(character);
     const enemy = EnemyManager.createEnemy(initialGameState.floor);
-
-    // Initialize combat manager
     const combat = new CombatManager(initialGameState, [enemy]);
 
     setGameState(initialGameState);
     setEnemies([enemy]);
     setCombatManager(combat);
-  }, [character?.id]); // Only re-run when character ID changes
-
-  useEffect(() => {
-    if (gameState?.status === "VICTORY") {
-      setDefeatedEnemies((prev) => [...prev, ...enemies]);
-    }
-  }, [gameState?.status, enemies]);
+  }, [character?.id]);
 
   if (!character) return null;
 
-  const handleVictory = async () => {
-    if (!character || !gameState) return;
-
+  const handleVictory = async (
+    resolvedGameState: GameState,
+    defeatedEnemies: Enemy[]
+  ) => {
     try {
-      // Calculate rewards with fixed base values
-      const goldReward = Math.floor(Math.random() * 10) + 5;
+      const combatRewards = calculateCombatRewards(
+        defeatedEnemies,
+        resolvedGameState.floor
+      );
 
-      // Calculate experience reward based on enemy type and floor level
-      let expReward = 0;
-      defeatedEnemies.forEach((enemy) => {
-        const floorMultiplier = Math.max(1, Math.floor(gameState.floor / 5));
-        if (enemy.isBoss) {
-          expReward += 50 * floorMultiplier;
-        } else if (enemy.isElite) {
-          expReward += 25 * floorMultiplier;
-        } else {
-          expReward += 10 * floorMultiplier;
-        }
-      });
-
-      // Ensure minimum experience reward
-      expReward = Math.max(10, expReward);
-
-      // Calculate new values
-      const newGold = character.gold + goldReward;
-      const newExp = character.experience + expReward;
-      const currentMonstersSlain = character.monstersSlain || 0;
-      const newMonstersSlain = currentMonstersSlain + enemies.length; // Use enemies.length instead of defeatedEnemies
-
-      // Log the values for debugging
-      console.log("Updating character stats:", {
-        currentMonstersSlain,
-        newMonstersSlain,
-        enemiesDefeated: enemies.length,
-      });
-
-      // Update character stats
       const updatedCharacter = await updateCharacter(character.id, {
-        gold: newGold,
-        experience: newExp,
-        currentHealth: Math.max(1, gameState.character.currentHealth),
-        monstersSlain: newMonstersSlain,
-        floor: gameState.floor, // Make sure to include the current floor
+        gold: character.gold + combatRewards.gold,
+        experience: character.experience + combatRewards.experience,
+        currentHealth: Math.max(1, resolvedGameState.character.currentHealth),
+        monstersSlain:
+          (character.monstersSlain || 0) + combatRewards.monstersSlain,
+        floor: resolvedGameState.floor,
       });
 
       if (!updatedCharacter) {
         throw new Error("Failed to update character stats");
       }
 
-      // Clear defeated enemies for next combat
-      setDefeatedEnemies([]);
-
-      // Update the rewards display
       setRewards({
-        gold: goldReward,
-        experience: expReward,
-        floor: gameState.floor,
+        gold: combatRewards.gold,
+        experience: combatRewards.experience,
+        floor: resolvedGameState.floor,
       });
-
       setShowVictory(true);
     } catch (error) {
       console.error("Failed to update character:", error);
@@ -165,29 +121,25 @@ export default function Combat({ onCombatEnd, onExit }: CombatProps) {
     }
   };
 
+  const initializeBattle = (nextGameState: GameState) => {
+    const enemy = EnemyManager.createEnemy(nextGameState.floor);
+    const combat = new CombatManager(nextGameState, [enemy]);
+
+    setGameState(nextGameState);
+    setEnemies([enemy]);
+    setCombatManager(combat);
+  };
+
   const handleRevive = async () => {
     try {
       await reviveCharacter(character.id);
-
-      // Reset game state
-      const enhancedCharacter = {
+      const revivedState = createGameState({
         ...character,
         currentHealth: character.maxHealth,
         isDead: false,
-      };
+      });
 
-      const gameManager = new GameManager(enhancedCharacter);
-      const initialGameState = gameManager.getState();
-
-      // Create a new enemy for the current floor
-      const enemy = EnemyManager.createEnemy(initialGameState.floor);
-
-      // Initialize combat manager
-      const combat = new CombatManager(initialGameState, [enemy]);
-
-      setGameState(initialGameState);
-      setEnemies([enemy]);
-      setCombatManager(combat);
+      initializeBattle(revivedState);
       setShowDefeat(false);
     } catch (error) {
       console.error("Failed to revive character:", error);
@@ -195,29 +147,27 @@ export default function Combat({ onCombatEnd, onExit }: CombatProps) {
   };
 
   const handleNextFloor = async () => {
-    if (!character || !gameState) return;
+    if (!gameState) return;
 
-    // Clear defeated enemies for next combat
-    setDefeatedEnemies([]);
-
-    const nextFloor = (gameState.floor || 1) + 1;
+    const nextFloor = gameState.floor + 1;
 
     try {
-      await updateCharacter(character.id, {
-        floor: nextFloor,
-      });
+      await updateCharacter(character.id, { floor: nextFloor });
 
-      // Special case: force rest site every 5 floors
       if (nextFloor % 5 === 0) {
         router.push(`/dashboard/game/${character.id}/rest`);
         return;
       }
 
-      // Generate 2 random unique room options
-      const possibleRooms = [RoomType.BATTLE, RoomType.REST, RoomType.SHOP, RoomType.EVENT];
-      const numberOfChoices = 2; // Changed from 3 to 2
-      const shuffledRooms = [...possibleRooms].sort(() => Math.random() - 0.5);
-      const selectedRooms = shuffledRooms.slice(0, numberOfChoices);
+      const possibleRooms = [
+        RoomType.BATTLE,
+        RoomType.REST,
+        RoomType.SHOP,
+        RoomType.EVENT,
+      ];
+      const selectedRooms = [...possibleRooms]
+        .sort(() => Math.random() - 0.5)
+        .slice(0, 2);
 
       setAvailableRooms(selectedRooms);
       setShowRoomSelection(true);
@@ -230,99 +180,68 @@ export default function Combat({ onCombatEnd, onExit }: CombatProps) {
   const handleRoomSelection = (selectedRoom: RoomType) => {
     setShowRoomSelection(false);
 
-    switch (selectedRoom) {
-      case RoomType.REST:
-        router.push(`/dashboard/game/${character.id}/rest`);
-        break;
-      case RoomType.SHOP:
-        router.push(`/dashboard/game/${character.id}/shop`);
-        break;
-      case RoomType.EVENT:
-        router.push(`/dashboard/game/${character.id}/event`);
-        break;
-      case RoomType.BATTLE:
-        // Initialize game state with enhanced character for next floor
-        const enhancedCharacter: Character = {
-          ...character,
-          equipment: character.equipment || [],
-          powers: character.powers || [],
-          block: 0,
-          deck: [],
-          hand: [],
-          discardPile: [],
-        };
-
-        const gameManager = new GameManager(enhancedCharacter);
-        const initialGameState = gameManager.getState();
-        initialGameState.floor = (gameState?.floor || 1) + 1;
-
-        setGameState(initialGameState);
-        setShowVictory(false);
-        initializeBattle(initialGameState);
-        break;
+    if (selectedRoom === RoomType.REST) {
+      router.push(`/dashboard/game/${character.id}/rest`);
+      return;
     }
+
+    if (selectedRoom === RoomType.SHOP) {
+      router.push(`/dashboard/game/${character.id}/shop`);
+      return;
+    }
+
+    if (selectedRoom === RoomType.EVENT) {
+      router.push(`/dashboard/game/${character.id}/event`);
+      return;
+    }
+
+    const nextFloor = (gameState?.floor || character.floor || 1) + 1;
+    const nextGameState = createGameState(character, nextFloor);
+    setShowVictory(false);
+    initializeBattle(nextGameState);
   };
 
-  const initializeBattle = (gameState: GameState) => {
-    // Create a new enemy for the current floor
-    const enemy = EnemyManager.createEnemy(gameState.floor);
-
-    // Initialize combat manager
-    const combat = new CombatManager(gameState, [enemy]);
-
-    setEnemies([enemy]);
-    setCombatManager(combat);
-  };
-
-  const handleCardClick = (index: number) => {
+  const handleCardClick = async (index: number) => {
     if (!gameState || !combatManager) return;
 
     const card = gameState.hand[index];
-    if (card.energy > gameState.currentEnergy) return; // Can't play if not enough energy
+    if (!card || card.energy > gameState.currentEnergy) return;
 
-    // For now, we'll assume single target cards always target the first enemy
-    const targetIndex = 0;
+    if (!combatManager.playCard(index, 0)) return;
 
-    if (combatManager.playCard(index, targetIndex)) {
-      const updatedGameState = { ...combatManager.getState() };
-      const updatedEnemies = [...combatManager.getCombatState().enemies];
-      
-      setGameState(updatedGameState);
-      setEnemies(updatedEnemies);
+    const updatedGameState = combatManager.getState();
+    const updatedCombatState = combatManager.getCombatState();
 
-      // Check for victory condition after playing a card
-      if (updatedEnemies.every(enemy => enemy.currentHealth <= 0)) {
-        setDefeatedEnemies(updatedEnemies);
-        handleVictory();
-      }
+    setGameState(updatedGameState);
+    setEnemies(updatedCombatState.enemies);
+
+    if (updatedGameState.status === "VICTORY") {
+      await handleVictory(
+        updatedGameState,
+        updatedCombatState.defeatedEnemies
+      );
     }
   };
 
-  const handleEndTurn = () => {
-    if (!combatManager || !gameState) return;
+  const handleEndTurn = async () => {
+    if (!combatManager || !combatManager.endTurn()) return;
 
-    // Process enemy actions
-    combatManager.processEnemyTurn();
-
-    // Move all cards from hand to discard pile
-    combatManager.endTurn();
-
-    // Update both states
     const updatedGameState = combatManager.getState();
-    const updatedEnemies = [...combatManager.getCombatState().enemies];
-    
-    setGameState({ ...updatedGameState });
-    setEnemies(updatedEnemies);
+    const updatedCombatState = combatManager.getCombatState();
 
-    // Check game status
+    setGameState(updatedGameState);
+    setEnemies(updatedCombatState.enemies);
+
     if (updatedGameState.status === "DEFEAT") {
-      handleCombatDefeat();
+      await handleCombatDefeat();
     }
   };
 
   const getHealthBarColor = (percentage: number) => {
     if (percentage > 66) return "bg-gradient-to-r from-red-600 to-red-500";
-    if (percentage > 33) return "bg-gradient-to-r from-yellow-600 to-yellow-500";
+    if (percentage > 33) {
+      return "bg-gradient-to-r from-yellow-600 to-yellow-500";
+    }
     return "bg-gradient-to-r from-red-800 to-red-700";
   };
 
@@ -333,56 +252,50 @@ export default function Combat({ onCombatEnd, onExit }: CombatProps) {
   return (
     <div className="min-h-screen w-full bg-gradient-to-b from-gray-50 to-gray-100">
       <div className="container mx-auto px-2 md:px-4">
-        <div className="relative min-h-[calc(100vh-4rem)] md:h-[calc(100vh-12rem)] w-full pb-[280px] md:pb-32">
-          {/* Enemy Area */}
-          <div className="flex flex-wrap justify-center gap-4 md:gap-4 p-4 md:p-8 mb-[100px]">
-            {enemies.map((enemy, index) => (
+        <div className="relative min-h-[calc(100vh-4rem)] w-full pb-[280px] md:h-[calc(100vh-12rem)] md:pb-32">
+          <div className="mb-[100px] flex flex-wrap justify-center gap-4 p-4 md:p-8">
+            {enemies.map((enemy) => (
               <div
                 key={enemy.id}
-                className="relative w-full max-w-xs p-2 bg-gradient-to-b from-gray-500 to-gray-700 rounded-xl border border-gray-700 shadow-lg overflow-hidden pb-4"
+                className="relative w-full max-w-xs overflow-hidden rounded-xl border border-gray-700 bg-gradient-to-b from-gray-500 to-gray-700 p-2 pb-4 shadow-lg"
               >
-                <div className="flex justify-between items-center text-lg md:text-xl font-bold mb-2 text-white">
+                <div className="mb-2 flex items-center justify-between text-lg font-bold text-white md:text-xl">
                   <span>{enemy.name}</span>
-                  <span className="bg-gray-700/50 rounded-full p-1.5">
+                  <span className="rounded-full bg-gray-700/50 p-1.5">
                     <Skull className="h-5 w-5 text-red-400" />
                   </span>
                 </div>
 
-                <div className="space-y-2">
-                  <div className="pt-4 pb-2">
-                    <div className="flex justify-between items-center mb-1.5">
-                      <span className="text-sm font-medium text-white">HP</span>
-                      <span className="text-sm font-medium text-white">
-                        {enemy.currentHealth}/{enemy.maxHealth}
-                      </span>
-                    </div>
-                    <div className="h-3 bg-gray-700/60 rounded-full overflow-hidden">
-                      <div
-                        className={`h-full transition-all duration-300 rounded-full ${getHealthBarColor(
-                          (enemy.currentHealth / enemy.maxHealth) * 100
-                        )}`}
-                        style={{
-                          width: `${(enemy.currentHealth / enemy.maxHealth) * 100}%`,
-                        }}
-                      />
-                    </div>
+                <div className="pt-4 pb-2">
+                  <div className="mb-1.5 flex items-center justify-between">
+                    <span className="text-sm font-medium text-white">HP</span>
+                    <span className="text-sm font-medium text-white">
+                      {enemy.currentHealth}/{enemy.maxHealth}
+                    </span>
+                  </div>
+                  <div className="h-3 overflow-hidden rounded-full bg-gray-700/60">
+                    <div
+                      className={`h-full rounded-full transition-all duration-300 ${getHealthBarColor(
+                        (enemy.currentHealth / enemy.maxHealth) * 100
+                      )}`}
+                      style={{
+                        width: `${(enemy.currentHealth / enemy.maxHealth) * 100}%`,
+                      }}
+                    />
                   </div>
                 </div>
               </div>
             ))}
           </div>
 
-          {/* Bottom UI Container */}
-          <div className="fixed bottom-0 left-0 right-0 z-10">
-            {/* Character Stats Panel */}
-            <div className="px-2 md:px-4 mb-2">
+          <div className="fixed right-0 bottom-0 left-0 z-10">
+            <div className="mb-2 px-2 md:px-4">
               <CharacterStats gameState={gameState} />
             </div>
 
-            {/* Hand Area */}
-            <div className="h-36 md:h-48 bg-gradient-to-t from-gray-900/20 to-transparent">
-              <div className="p-2 md:p-4 overflow-x-auto pb-2 hide-scrollbar h-full">
-                <div className="flex gap-2 md:gap-3 min-w-min justify-start md:justify-center h-full">
+            <div className="h-36 bg-gradient-to-t from-gray-900/20 to-transparent md:h-48">
+              <div className="hide-scrollbar h-full overflow-x-auto p-2 pb-2 md:p-4">
+                <div className="flex h-full min-w-min justify-start gap-2 md:justify-center md:gap-3">
                   {gameState.hand.map((card, index) => (
                     <Card
                       key={`${card.id}-${index}`}
@@ -395,20 +308,17 @@ export default function Combat({ onCombatEnd, onExit }: CombatProps) {
                 </div>
               </div>
 
-              {/* Button Container */}
-              <div className="absolute bottom-2 md:bottom-4 left-0 right-0 flex justify-between px-2 md:px-4">
-                {/* Exit Button */}
+              <div className="absolute right-0 bottom-2 left-0 flex justify-between px-2 md:bottom-4 md:px-4">
                 <button
                   onClick={onExit}
-                  className="px-3 md:px-4 py-1.5 md:py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm md:text-base transition-colors duration-200"
+                  className="rounded-lg bg-red-600 px-3 py-1.5 text-sm text-white transition-colors duration-200 hover:bg-red-700 md:px-4 md:py-2 md:text-base"
                 >
                   Exit Game
                 </button>
 
-                {/* End Turn Button */}
                 <button
                   onClick={handleEndTurn}
-                  className="px-4 md:px-6 py-2 md:py-3 bg-primary hover:bg-primary-dark text-white rounded-lg font-medievalsharp text-base md:text-lg shadow-lg transition-all duration-200 hover:shadow-xl"
+                  className="bg-primary hover:bg-primary-dark rounded-lg px-4 py-2 font-medievalsharp text-base text-white shadow-lg transition-all duration-200 hover:shadow-xl md:px-6 md:py-3 md:text-lg"
                 >
                   End Turn
                 </button>
@@ -416,7 +326,6 @@ export default function Combat({ onCombatEnd, onExit }: CombatProps) {
             </div>
           </div>
 
-          {/* Add this CSS to your global styles */}
           <style jsx global>{`
             .hide-scrollbar {
               -ms-overflow-style: none;
@@ -429,28 +338,25 @@ export default function Combat({ onCombatEnd, onExit }: CombatProps) {
 
           <GameModal
             isOpen={showVictory}
-            onClose={() => {
-              setShowVictory(false);
-              onCombatEnd();
-            }}
+            onClose={() => setShowVictory(false)}
             type="victory"
-            rewards={{
-              gold: rewards.gold,
-              experience: rewards.experience,
-              floor: gameState?.floor || 1,
-            }}
+            rewards={rewards}
             onNextFloor={handleNextFloor}
           />
           <GameModal
             isOpen={showDefeat}
-            onClose={() => {
-              setShowDefeat(false);
-              onCombatEnd();
-            }}
+            onClose={() => setShowDefeat(false)}
             type="defeat"
             onRevive={handleRevive}
             crystalCost={100}
             userCrystals={userCrystals}
+          />
+          <RoomSelectionModal
+            isOpen={showRoomSelection}
+            onClose={() => setShowRoomSelection(false)}
+            onSelectRoom={handleRoomSelection}
+            availableRooms={availableRooms}
+            currentFloor={gameState.floor}
           />
         </div>
       </div>

--- a/lib/cards.ts
+++ b/lib/cards.ts
@@ -12,7 +12,7 @@ export type Card = {
   };
 };
 
-type FightingStyle = "MELEE" | "RANGE" | "MAGIC";
+export type FightingStyle = "MELEE" | "RANGE" | "MAGIC";
 
 export function getStarterDeck(fightingStyle: FightingStyle): Card[] {
   const basicStrikes = Array(4).fill({

--- a/lib/game/combat-manager.ts
+++ b/lib/game/combat-manager.ts
@@ -1,39 +1,53 @@
-import { GameState } from "./game-state";
-import { Enemy } from "./enemy";
-import { Card } from "@/types/character";
+import type { Card } from "../cards";
+import type { Enemy } from "./enemy";
+import type { GameState } from "./game-state";
+import { shuffle, type RandomSource } from "./random.ts";
 
 export type CombatState = {
   enemies: Enemy[];
+  defeatedEnemies: Enemy[];
   turn: number;
   isPlayerTurn: boolean;
 };
 
 export class CombatManager {
+  private readonly random: RandomSource;
   private gameState: GameState;
   private combatState: CombatState;
 
-  constructor(gameState: GameState, enemies: Enemy[]) {
+  constructor(
+    gameState: GameState,
+    enemies: Enemy[],
+    random: RandomSource = Math.random
+  ) {
     this.gameState = gameState;
+    this.random = random;
     this.combatState = {
-      enemies,
+      enemies: enemies.map((enemy) => ({
+        ...enemy,
+        intent: { ...enemy.intent },
+      })),
+      defeatedEnemies: [],
       turn: 1,
       isPlayerTurn: true,
     };
 
-    // Initialize combat state
-    this.drawNewHand();
+    if (this.gameState.hand.length === 0) {
+      this.drawNewHand();
+    }
   }
 
-  playCard(cardIndex: number, targetIndex: number): boolean {
+  playCard(cardIndex: number, targetIndex = 0): boolean {
+    if (!this.combatState.isPlayerTurn || this.gameState.status !== "PLAYING") {
+      return false;
+    }
+
     if (cardIndex < 0 || cardIndex >= this.gameState.hand.length) return false;
 
     const card = this.gameState.hand[cardIndex];
     if (card.energy > this.gameState.currentEnergy) return false;
 
-    // Apply card effects
     this.applyCardEffects(card, targetIndex);
-
-    // Move card to discard pile
     this.gameState.hand.splice(cardIndex, 1);
     this.gameState.discardPile.push(card);
     this.gameState.currentEnergy -= card.energy;
@@ -45,7 +59,19 @@ export class CombatManager {
     const effects = card.effects;
 
     if (effects.damage) {
-      this.dealDamage("player", effects.damage, targetIndex);
+      if (effects.special === "twice") {
+        const target = this.combatState.enemies[targetIndex];
+        if (target) {
+          this.dealDamageToEnemy(target, effects.damage);
+          this.dealDamageToEnemy(target, effects.damage);
+        }
+      } else if (effects.special === "aoe") {
+        const targets = [...this.combatState.enemies];
+        targets.forEach((target) => this.dealDamageToEnemy(target, effects.damage!));
+      } else {
+        const target = this.combatState.enemies[targetIndex];
+        if (target) this.dealDamageToEnemy(target, effects.damage);
+      }
     }
 
     if (effects.block) {
@@ -58,121 +84,114 @@ export class CombatManager {
         this.gameState.character.maxHealth
       );
     }
-
-    // Handle special effects
-    if (effects.special) {
-      switch (effects.special) {
-        case "twice":
-          if (effects.damage) {
-            this.dealDamage("player", effects.damage, targetIndex);
-          }
-          break;
-        case "aoe":
-          if (effects.damage) {
-            this.combatState.enemies.forEach((_, index) => {
-              this.dealDamage("player", effects.damage!, index);
-            });
-          }
-          break;
-      }
-    }
   }
 
-  dealDamage(source: "player" | "enemy", damage: number, targetIndex: number) {
-    if (source === "player") {
-      const enemy = this.combatState.enemies[targetIndex];
-      if (!enemy) return;
+  private dealDamageToEnemy(enemy: Enemy, damage: number) {
+    const targetIndex = this.combatState.enemies.indexOf(enemy);
+    if (targetIndex < 0) return;
 
-      const actualDamage = Math.max(0, damage - enemy.block);
-      enemy.block = Math.max(0, enemy.block - damage);
-      enemy.currentHealth -= actualDamage;
+    const actualDamage = Math.max(0, damage - enemy.block);
+    enemy.block = Math.max(0, enemy.block - damage);
+    enemy.currentHealth = Math.max(0, enemy.currentHealth - actualDamage);
 
-      if (enemy.currentHealth <= 0) {
-        this.combatState.enemies = this.combatState.enemies.filter(
-          (_, i) => i !== targetIndex
-        );
-        // Check for victory when all enemies are defeated
-        if (this.combatState.enemies.length === 0) {
-          this.gameState.status = "VICTORY";
-        }
-      }
-    } else {
-      const actualDamage = Math.max(0, damage - this.gameState.block);
-      this.gameState.block = Math.max(0, this.gameState.block - damage);
-      this.gameState.character.currentHealth -= actualDamage;
+    if (enemy.currentHealth !== 0) return;
 
-      // Check for defeat when character health reaches 0
-      if (this.gameState.character.currentHealth <= 0) {
-        this.gameState.character.currentHealth = 0; // Ensure health doesn't go negative
-        this.gameState.status = "DEFEAT";
-      }
-    }
-  }
-
-  processEnemyTurn() {
-    this.combatState.enemies.forEach((enemy) => {
-      switch (enemy.intent.type) {
-        case "ATTACK":
-          this.dealDamage("enemy", enemy.intent.value, 0);
-          break;
-        case "BLOCK":
-          enemy.block += enemy.intent.value;
-          break;
-        // Handle other intent types
-      }
+    this.combatState.defeatedEnemies.push({
+      ...enemy,
+      intent: { ...enemy.intent },
     });
+    this.combatState.enemies.splice(targetIndex, 1);
+
+    if (this.combatState.enemies.length === 0) {
+      this.gameState.status = "VICTORY";
+      this.combatState.isPlayerTurn = false;
+    }
   }
 
-  isCombatOver(): boolean {
-    return (
-      this.combatState.enemies.length === 0 ||
-      this.gameState.character.currentHealth <= 0
+  private dealDamageToPlayer(damage: number) {
+    const actualDamage = Math.max(0, damage - this.gameState.block);
+    this.gameState.block = Math.max(0, this.gameState.block - damage);
+    this.gameState.character.currentHealth = Math.max(
+      0,
+      this.gameState.character.currentHealth - actualDamage
     );
+
+    if (this.gameState.character.currentHealth === 0) {
+      this.gameState.status = "DEFEAT";
+      this.combatState.isPlayerTurn = false;
+    }
   }
 
-  getCombatState(): CombatState {
-    return { ...this.combatState };
-  }
+  endTurn(): boolean {
+    if (!this.combatState.isPlayerTurn || this.gameState.status !== "PLAYING") {
+      return false;
+    }
 
-  getState(): GameState {
-    return { ...this.gameState };
-  }
-
-  endTurn() {
-    // Move hand to discard pile
     this.gameState.discardPile.push(...this.gameState.hand);
     this.gameState.hand = [];
+    this.combatState.isPlayerTurn = false;
 
-    // Reset energy
-    this.gameState.currentEnergy = this.gameState.maxEnergy;
+    this.processEnemyTurn();
 
-    // Reset block
-    this.gameState.block = 0;
-
-    // Process enemy actions if it's not game over
-    if (!this.isCombatOver()) {
-      this.processEnemyTurn();
+    if (this.gameState.status === "PLAYING") {
+      this.gameState.block = 0;
+      this.gameState.currentEnergy = this.gameState.maxEnergy;
+      this.drawNewHand();
+      this.combatState.turn += 1;
+      this.combatState.isPlayerTurn = true;
     }
 
-    // Draw new hand if combat is still ongoing
-    if (!this.isCombatOver()) {
-      this.drawNewHand();
+    return true;
+  }
+
+  private processEnemyTurn() {
+    for (const enemy of this.combatState.enemies) {
+      if (this.gameState.status !== "PLAYING") return;
+
+      if (enemy.intent.type === "ATTACK") {
+        this.dealDamageToPlayer(enemy.intent.value);
+      } else if (enemy.intent.type === "BLOCK") {
+        enemy.block += enemy.intent.value;
+      }
     }
   }
 
   private drawNewHand() {
-    for (let i = 0; i < 5; i++) {
+    for (let index = 0; index < 5; index += 1) {
       if (this.gameState.drawPile.length === 0) {
-        // Shuffle discard pile into draw pile
-        this.gameState.drawPile = [...this.gameState.discardPile].sort(
-          () => Math.random() - 0.5
-        );
+        if (this.gameState.discardPile.length === 0) return;
+        this.gameState.drawPile = shuffle(this.gameState.discardPile, this.random);
         this.gameState.discardPile = [];
       }
-      if (this.gameState.drawPile.length > 0) {
-        const card = this.gameState.drawPile.pop()!;
-        this.gameState.hand.push(card);
-      }
+
+      const card = this.gameState.drawPile.pop();
+      if (!card) return;
+      this.gameState.hand.push(card);
     }
+  }
+
+  getCombatState(): CombatState {
+    return {
+      ...this.combatState,
+      enemies: this.combatState.enemies.map((enemy) => ({
+        ...enemy,
+        intent: { ...enemy.intent },
+      })),
+      defeatedEnemies: this.combatState.defeatedEnemies.map((enemy) => ({
+        ...enemy,
+        intent: { ...enemy.intent },
+      })),
+    };
+  }
+
+  getState(): GameState {
+    return {
+      ...this.gameState,
+      character: { ...this.gameState.character },
+      deck: [...this.gameState.deck],
+      hand: [...this.gameState.hand],
+      discardPile: [...this.gameState.discardPile],
+      drawPile: [...this.gameState.drawPile],
+    };
   }
 }

--- a/lib/game/game-state.ts
+++ b/lib/game/game-state.ts
@@ -1,15 +1,10 @@
 "use client";
-import { Character } from "@/types/character";
-import { Card, getStarterDeck } from "@/lib/cards";
-import { Enemy } from "./enemy";
-import { FightingStyle } from "@prisma/client";
 
-// Add these new types at the top
-export type CombatState = {
-  enemies: Enemy[];
-  turn: number;
-  isPlayerTurn: boolean;
-};
+import type { Character } from "../../types/character";
+import { getStarterDeck, type Card, type FightingStyle } from "../cards.ts";
+import { shuffle, type RandomSource } from "./random.ts";
+
+export type GameStatus = "PLAYING" | "VICTORY" | "DEFEAT";
 
 export type GameState = {
   floor: number;
@@ -21,153 +16,54 @@ export type GameState = {
   discardPile: Card[];
   drawPile: Card[];
   block: number;
-  status: "PLAYING" | "VICTORY" | "DEFEAT";
-  combatState?: CombatState;
+  status: GameStatus;
 };
 
 export class GameManager {
+  private readonly random: RandomSource;
   private state: GameState;
 
-  constructor(character: Character) {
-    // Get starter deck based on character's class
+  constructor(character: Character, random: RandomSource = Math.random) {
+    this.random = random;
     const starterDeck = getStarterDeck(character.class as FightingStyle);
 
     this.state = {
-      floor: 1,
-      character,
+      floor: Math.max(1, character.floor || 1),
+      character: { ...character },
       currentEnergy: character.energy,
       maxEnergy: character.energy,
-      deck: starterDeck, // Use the starter deck instead of character.deck
+      deck: starterDeck,
       hand: [],
       discardPile: [],
-      drawPile: [],
+      drawPile: shuffle(starterDeck, this.random),
       block: 0,
       status: "PLAYING",
     };
-    this.initializeGame();
+
+    this.drawCards(5);
   }
 
-  private initializeGame() {
-    this.state.drawPile = this.shuffleArray([...this.state.deck]);
-    this.drawInitialHand();
-  }
-
-  private shuffleArray<T>(array: T[]): T[] {
-    const newArray = [...array];
-    for (let i = newArray.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [newArray[i], newArray[j]] = [newArray[j], newArray[i]];
-    }
-    return newArray;
-  }
-
-  drawCard(count: number = 1) {
-    for (let i = 0; i < count; i++) {
-      if (this.state.drawPile.length === 0) {
-        this.reshuffleDiscardPile();
+  private drawCards(count: number) {
+    for (let index = 0; index < count; index += 1) {
+      if (this.state.drawPile.length === 0 && this.state.discardPile.length > 0) {
+        this.state.drawPile = shuffle(this.state.discardPile, this.random);
+        this.state.discardPile = [];
       }
-      if (this.state.drawPile.length > 0) {
-        const card = this.state.drawPile.pop()!;
-        this.state.hand.push(card);
-      }
+
+      const card = this.state.drawPile.pop();
+      if (!card) return;
+      this.state.hand.push(card);
     }
-  }
-
-  private drawInitialHand() {
-    this.drawCard(5);
-  }
-
-  private reshuffleDiscardPile() {
-    this.state.drawPile = this.shuffleArray([...this.state.discardPile]);
-    this.state.discardPile = [];
-  }
-
-  playCard(cardIndex: number, targetIndex?: number) {
-    if (cardIndex < 0 || cardIndex >= this.state.hand.length) return false;
-
-    const card = this.state.hand[cardIndex];
-    if (card.energy > this.state.currentEnergy) return false;
-
-    // Apply card effects
-    this.applyCardEffects(card, targetIndex);
-
-    // Move card to discard pile
-    this.state.hand.splice(cardIndex, 1);
-    this.state.discardPile.push(card);
-    this.state.currentEnergy -= card.energy;
-
-    return true;
-  }
-
-  private applyCardEffects(card: Card, targetIndex?: number) {
-    const effects = card.effects;
-
-    if (effects.block) {
-      this.state.block += effects.block;
-    }
-
-    if (effects.heal) {
-      this.state.character.currentHealth = Math.min(
-        this.state.character.currentHealth + effects.heal,
-        this.state.character.maxHealth
-      );
-    }
-
-    // Handle special effects based on card type and fighting style
-    if (effects.special) {
-      this.handleSpecialEffects(card, effects.special, targetIndex);
-    }
-  }
-
-  private handleSpecialEffects(
-    card: Card,
-    special: string,
-    targetIndex?: number
-  ) {
-    switch (special) {
-      case "twice":
-        // Apply damage effect twice
-        break;
-      case "aoe":
-        // Apply damage to all enemies
-        break;
-      // Add more special effects as needed
-    }
-  }
-
-  endTurn() {
-    // Move hand to discard pile
-    this.state.discardPile.push(...this.state.hand);
-    this.state.hand = [];
-
-    // Reset energy
-    this.state.currentEnergy = this.state.maxEnergy;
-
-    // Reset block
-    this.state.block = 0;
-
-    // Draw new hand
-    this.drawInitialHand();
   }
 
   getState(): GameState {
-    return { ...this.state };
+    return {
+      ...this.state,
+      character: { ...this.state.character },
+      deck: [...this.state.deck],
+      hand: [...this.state.hand],
+      discardPile: [...this.state.discardPile],
+      drawPile: [...this.state.drawPile],
+    };
   }
-}
-
-// Move this to an API route
-export async function handleCharacterDeath(characterId: string) {
-  const response = await fetch("/api/character/death", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ characterId }),
-  });
-
-  if (!response.ok) {
-    throw new Error("Failed to handle character death");
-  }
-
-  return response.json();
 }

--- a/lib/game/random.ts
+++ b/lib/game/random.ts
@@ -1,0 +1,30 @@
+export type RandomSource = () => number;
+
+export function createSeededRandom(seed: number): RandomSource {
+  let state = seed >>> 0;
+
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function shuffle<T>(
+  items: readonly T[],
+  random: RandomSource = Math.random
+): T[] {
+  const shuffled = [...items];
+
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(random() * (index + 1));
+    [shuffled[index], shuffled[swapIndex]] = [
+      shuffled[swapIndex],
+      shuffled[index],
+    ];
+  }
+
+  return shuffled;
+}

--- a/lib/game/rewards.ts
+++ b/lib/game/rewards.ts
@@ -1,0 +1,30 @@
+import type { Enemy } from "./enemy";
+import type { RandomSource } from "./random.ts";
+
+export type CombatRewards = {
+  gold: number;
+  experience: number;
+  monstersSlain: number;
+};
+
+export function calculateCombatRewards(
+  defeatedEnemies: readonly Enemy[],
+  floor: number,
+  random: RandomSource = Math.random
+): CombatRewards {
+  const normalizedFloor = Math.max(1, Math.floor(floor));
+  const floorMultiplier = Math.max(1, Math.floor(normalizedFloor / 5));
+  const goldRoll = Math.min(0.999999999, Math.max(0, random()));
+
+  const experience = defeatedEnemies.reduce((total, enemy) => {
+    if (enemy.isBoss) return total + 50 * floorMultiplier;
+    if (enemy.isElite) return total + 25 * floorMultiplier;
+    return total + 10 * floorMultiplier;
+  }, 0);
+
+  return {
+    gold: Math.floor(goldRoll * 10) + 5,
+    experience: Math.max(10, experience),
+    monstersSlain: defeatedEnemies.length,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "test": "node --experimental-strip-types --test tests/game/*.test.ts",
     "postinstall": "npx prisma generate"
   },
   "dependencies": {

--- a/tests/game/combat-manager.test.ts
+++ b/tests/game/combat-manager.test.ts
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { CombatManager } from "../../lib/game/combat-manager.ts";
+import type { Card } from "../../lib/cards";
+import type { Enemy } from "../../lib/game/enemy";
+import type { GameState } from "../../lib/game/game-state";
+
+const strike: Card = {
+  id: "strike",
+  name: "Strike",
+  description: "Deal 6 damage.",
+  type: "ATTACK",
+  energy: 1,
+  effects: { damage: 6 },
+};
+
+function createState(): GameState {
+  return {
+    floor: 1,
+    character: {
+      id: "character-1",
+      name: "Test",
+      class: "MELEE",
+      floor: 1,
+      level: 1,
+      experience: 0,
+      currentHealth: 100,
+      maxHealth: 100,
+      energy: 3,
+      gold: 0,
+      equipment: [],
+      powers: [],
+      isDead: false,
+      block: 0,
+      deck: [],
+      hand: [],
+      discardPile: [],
+      monstersSlain: 0,
+      userId: "user-1",
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    },
+    currentEnergy: 3,
+    maxEnergy: 3,
+    deck: [strike],
+    hand: [strike],
+    discardPile: [],
+    drawPile: [strike, strike, strike, strike, strike],
+    block: 2,
+    status: "PLAYING",
+  };
+}
+
+function createEnemy(health = 20): Enemy {
+  return {
+    id: "skeleton",
+    name: "Skeleton",
+    currentHealth: health,
+    maxHealth: health,
+    block: 0,
+    intent: {
+      type: "ATTACK",
+      value: 6,
+      description: "Attack for 6",
+    },
+    isElite: false,
+    isBoss: false,
+  };
+}
+
+test("endTurn resolves exactly one enemy turn and starts the next player turn", () => {
+  const manager = new CombatManager(createState(), [createEnemy()]);
+
+  assert.equal(
+    manager.getState().hand.length,
+    1,
+    "the constructor must not draw a second opening hand"
+  );
+  assert.equal(manager.endTurn(), true);
+
+  const state = manager.getState();
+  const combat = manager.getCombatState();
+
+  assert.equal(
+    state.character.currentHealth,
+    96,
+    "2 block absorbs part of one 6-damage attack"
+  );
+  assert.equal(state.block, 0);
+  assert.equal(combat.turn, 2);
+  assert.equal(combat.isPlayerTurn, true);
+});
+
+test("defeated enemies remain available for victory rewards", () => {
+  const state = createState();
+  state.hand = [
+    {
+      ...strike,
+      effects: { damage: 20 },
+    },
+  ];
+  const manager = new CombatManager(state, [createEnemy(20)]);
+
+  assert.equal(manager.playCard(0, 0), true);
+  assert.equal(manager.getState().status, "VICTORY");
+  assert.equal(manager.getCombatState().enemies.length, 0);
+  assert.equal(manager.getCombatState().defeatedEnemies.length, 1);
+});

--- a/tests/game/game-state.test.ts
+++ b/tests/game/game-state.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { GameManager } from "../../lib/game/game-state.ts";
+import { createSeededRandom } from "../../lib/game/random.ts";
+import type { Character } from "../../types/character";
+
+function createCharacter(): Character {
+  return {
+    id: "character-1",
+    name: "Test",
+    class: "MELEE",
+    floor: 7,
+    level: 1,
+    experience: 0,
+    currentHealth: 100,
+    maxHealth: 100,
+    energy: 3,
+    gold: 0,
+    equipment: [],
+    powers: [],
+    isDead: false,
+    block: 0,
+    deck: [],
+    hand: [],
+    discardPile: [],
+    monstersSlain: 0,
+    userId: "user-1",
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+}
+
+test("game initialization preserves the persisted floor and draws five cards", () => {
+  const state = new GameManager(
+    createCharacter(),
+    createSeededRandom(7)
+  ).getState();
+
+  assert.equal(state.floor, 7);
+  assert.equal(state.hand.length, 5);
+  assert.equal(state.hand.length + state.drawPile.length, state.deck.length);
+});

--- a/tests/game/random.test.ts
+++ b/tests/game/random.test.ts
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createSeededRandom, shuffle } from "../../lib/game/random.ts";
+
+test("shuffle is deterministic for the same seed", () => {
+  const source = [1, 2, 3, 4, 5, 6];
+  const first = shuffle(source, createSeededRandom(42));
+  const second = shuffle(source, createSeededRandom(42));
+
+  assert.deepEqual(first, second);
+  assert.deepEqual(source, [1, 2, 3, 4, 5, 6]);
+});

--- a/tests/game/rewards.test.ts
+++ b/tests/game/rewards.test.ts
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { calculateCombatRewards } from "../../lib/game/rewards.ts";
+import type { Enemy } from "../../lib/game/enemy";
+
+const normal: Enemy = {
+  id: "normal",
+  name: "Normal",
+  currentHealth: 0,
+  maxHealth: 20,
+  block: 0,
+  intent: { type: "ATTACK", value: 5, description: "" },
+  isElite: false,
+  isBoss: false,
+};
+const elite: Enemy = { ...normal, id: "elite", isElite: true };
+
+test("rewards use the defeated enemy ledger", () => {
+  const rewards = calculateCombatRewards([normal, elite], 10, () => 0.5);
+
+  assert.deepEqual(rewards, {
+    gold: 10,
+    experience: 70,
+    monstersSlain: 2,
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary

Implements the first roadmap slice from `feat/core-run-stability`.

### Gameplay stability

- makes `CombatManager` the single owner of enemy-turn resolution
- prevents the duplicate opening hand
- preserves the persisted character floor when initializing combat
- prevents victory modal close handling from advancing the floor a second time
- keeps defeated enemies in a reward ledger after they are removed from active combat
- calculates rewards from the resolved combat snapshot instead of stale React state
- applies player block during the enemy phase and resets it afterward

### Determinism and tests

- adds a seeded random source and Fisher-Yates shuffle utility
- adds isolated tests for shuffle, game initialization, turn resolution, victory tracking, and rewards
- adds `npm test` and `npm run typecheck` commands without introducing a test framework dependency

### Documentation

- replaces the default Next.js README with the actual project status, setup, validation commands, and known limitations

## Validation

- `npm test`: 5 tests passed locally against the exact isolated domain files
- core TypeScript game modules passed strict `tsc --noEmit` validation in isolation
- updated React files passed TypeScript syntax transpilation
- verified the final branch diff contains only the 14 intended files

## Limitations

A full dependency install and Next.js production build could not be executed in the available environment because external package and repository network access was unavailable. The README keeps `npm run typecheck` and `npm run build` as required local verification steps.

No database schema, wallet/NFT implementation, dependencies, GitHub Actions, or CI/CD configuration changed.